### PR TITLE
Update history4feed version to 1.2.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -225,7 +225,7 @@ hdbscan==0.8.41
     # via obstracts (pyproject.toml)
 hf-xet==1.3.1
     # via huggingface-hub
-history4feed==1.2.9
+history4feed==1.2.10
     # via obstracts (pyproject.toml)
 httpcore==1.0.9
     # via httpx


### PR DESCRIPTION
fixes st failure caused by very long `post.categories` in  https://github.com/muchdogesec/obstracts/actions/runs/27336484907/job/80761901935#step:8:45786