### PR TITLE
Publish staging and prod image tags

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @himynamesdave

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @himynamesdave

--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -1,0 +1,53 @@
+name: Branch policy
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - staging
+      - main
+
+jobs:
+  validate:
+    name: Validate branch flow
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce promotion flow
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -eu
+
+          case "${BASE_REF}" in
+            develop)
+              if [ "${HEAD_REF}" = "main" ] || [ "${HEAD_REF}" = "staging" ]; then
+                echo "Pull requests into develop must not come from protected release branches."
+                exit 1
+              fi
+              ;;
+            staging)
+              case "${HEAD_REF}" in
+                develop|hotfix/*)
+                  ;;
+                *)
+                  echo "Pull requests into staging must come from develop or hotfix/*."
+                  exit 1
+                  ;;
+              esac
+              ;;
+            main)
+              case "${HEAD_REF}" in
+                staging|hotfix/*)
+                  ;;
+                *)
+                  echo "Pull requests into main must come from staging or hotfix/*."
+                  exit 1
+                  ;;
+              esac
+              ;;
+            *)
+              echo "No branch policy defined for base branch ${BASE_REF}."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/deploy-production-image.yml
+++ b/.github/workflows/deploy-production-image.yml
@@ -6,8 +6,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}_web_production
-  PACKAGE_NAME: ${{ github.event.repository.name }}_web_production
+  IMAGE_NAME: ${{ github.repository }}
+  PACKAGE_NAME: ${{ github.event.repository.name }}
 
 jobs:
   build-and-push-image:
@@ -31,6 +31,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=prod
+            type=sha,prefix=sha-
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6

--- a/.github/workflows/deploy-staging-image.yml
+++ b/.github/workflows/deploy-staging-image.yml
@@ -2,12 +2,12 @@ name: Create and publish the Docker image for Obstracts Web Staging
 
 on:
   push:
-    branches: ['main']
+    branches: ['staging']
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}_web_staging
-  PACKAGE_NAME: ${{ github.event.repository.name }}_web_staging
+  IMAGE_NAME: ${{ github.repository }}
+  PACKAGE_NAME: ${{ github.event.repository.name }}
 
 jobs:
   build-and-push-image:
@@ -31,6 +31,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=staging
+            type=sha,prefix=sha-
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6

--- a/.github/workflows/deploy-test-image.yml
+++ b/.github/workflows/deploy-test-image.yml
@@ -6,8 +6,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}_web_test
-  PACKAGE_NAME: ${{ github.event.repository.name }}_web_test
+  IMAGE_NAME: ${{ github.repository }}
+  PACKAGE_NAME: ${{ github.event.repository.name }}
 
 jobs:
   build-and-push-image:
@@ -32,6 +32,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=test
+            type=sha,prefix=test-sha-
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,11 +5,17 @@ permissions:
 on:
   push:
     branches:
+      - staging
       - main
   pull_request:
+    branches:
+      - develop
+      - staging
+      - main
     types:
       - opened
       - synchronize
+      - reopened
 
 jobs:
   test-pipeline:


### PR DESCRIPTION
## Summary
- publish unified GHCR images from this repo using :staging or :prod plus commit SHA tags
- trigger the staging image workflow from the staging branch instead of main
- expand CI checks to cover pull requests into develop, staging, and main where applicable
