### PR TITLE
Configure Dependabot updates for develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: develop
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: develop


### PR DESCRIPTION
Routes grouped Python and GitHub Actions Dependabot version updates to `develop`, so they follow the checked promotion path rather than targeting `main`.