### PR TITLE
docs: add staging delivery guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,15 @@ configuration when authorized, rerun validation, and continue the release
 workflow. Do not stop at reporting a blocker or wait for the user when a safe,
 available remediation exists; request help only when a required permission or
 external action is genuinely unavailable.
+
+## GitHub Delivery Ownership
+
+Own merge conflicts, stale PR bases, missing or pending required checks, and
+protection-rule failures through resolution on GitHub. Rebase or merge the
+approved target branch as needed, trigger fresh validation when a base-branch
+change did not do so, inspect the exact failing rule or job, and continue until
+the PR is mergeable. Do not leave a blocking condition for another agent or
+the user to resolve when a safe remediation is available.
 ## Delivery Workflow
 
 For reported product bugs, use GitHub Issues by default. Reproduce and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # Agent Instructions
 
+## Staging server access
+
+The staging server can be accessed using `https://app.obstracts.staging.signalscorps.com/`
+
+You can login with your email `codex@dogesec.com`
+
+Deploy staging through the `obstracts_web_deploy` repository using the staging
+target. Always deploy the `staging` branch and test the staged application in a
+browser before marking work complete.
 ## Elastic Debug Access
 
 - Kibana URL: `http://157.180.37.56:5601/`
@@ -10,6 +19,35 @@
 Do not store passwords, API keys, tokens, or exported production data in this
 repository.
 
+## Behavior Documentation
+
+When implementing non-obvious product behavior, especially filtering,
+permissions, data boundaries, or workflow invariants, document the rationale
+in the relevant code and cover it with a regression test. Do this as part of
+the change so future work preserves the intended behavior.
+
+## Agent Guidance Maintenance
+
+When the user provides a reusable workflow or working pattern, update every
+`AGENTS.md` in the DogeSec repositories so the instruction applies consistently
+to future work. Do not leave this guidance only in the repository currently
+being changed.
+
+## Issue Ownership
+
+Own each reported issue through implementation, a PR with terminal required
+checks, staging deployment, and acceptance validation. Only after the staging
+checks pass, add the `ready for review` label and comment on the issue tagging
+`@himynamesdave` with the verification evidence for human testing.
+
+## Active Delivery Blockers
+
+Treat CI failures, protection-rule errors, and blocked promotions as active
+implementation work. Diagnose the exact cause, update the branch or
+configuration when authorized, rerun validation, and continue the release
+workflow. Do not stop at reporting a blocker or wait for the user when a safe,
+available remediation exists; request help only when a required permission or
+external action is genuinely unavailable.
 ## Delivery Workflow
 
 For reported product bugs, use GitHub Issues by default. Reproduce and
@@ -23,6 +61,9 @@ Application changes promote from a feature branch to `develop`, then
 acceptance validation, then applies `ready for review` and comments tagging
 `@himynamesdave` with the verification evidence and review request.
 
+Use the `obstracts_web_deploy` repository's staging target for staging
+deployments. Do not mark work complete until the `staging` branch is deployed
+and the change is verified in a browser against the staging environment.
 ## Dependency Updates
 
 Treat every Dependabot or other dependency-update PR as unverified until its


### PR DESCRIPTION
Adds the staging URL and login email, and documents the required Obstracts staging deployment and browser-verification workflow.