### PR TITLE
Publish core test image from develop

### DIFF
--- a/.github/workflows/deploy-test-image.yml
+++ b/.github/workflows/deploy-test-image.yml
@@ -2,7 +2,7 @@ name: Create and publish the Docker image for Obstracts Web Test
 
 on:
   push:
-    branches: ['main']
+    branches: ['develop']
 
 env:
   REGISTRY: ghcr.io

--- a/obstracts/server/profiles.py
+++ b/obstracts/server/profiles.py
@@ -1,0 +1,19 @@
+from dogesec_commons.stixifier.serializers import ProfileSerializer
+from dogesec_commons.stixifier.views import ProfileView as CommonsProfileView
+from drf_spectacular.utils import extend_schema, extend_schema_view
+
+from . import autoschema as api_schema
+
+
+@extend_schema_view(
+    create=extend_schema(
+        responses={
+            400: api_schema.DEFAULT_400_ERROR,
+            201: ProfileSerializer,
+            415: api_schema.DEFAULT_415_ERROR,
+        }
+    )
+)
+class ProfileView(CommonsProfileView):
+    """Project schema additions for the shared profile endpoints."""
+

--- a/obstracts/server/views.py
+++ b/obstracts/server/views.py
@@ -121,6 +121,7 @@ class PlainMarkdownRenderer(renderers.BaseRenderer):
         responses={
             201: ObstractsJobSerializer,
             400: api_schema.DEFAULT_400_ERROR,
+            415: api_schema.DEFAULT_415_ERROR,
             406: FEED_406_ERROR,
         },
         summary="Create a New Feed",

--- a/obstracts/urls.py
+++ b/obstracts/urls.py
@@ -26,7 +26,8 @@ from rest_framework import routers, response
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 from django.conf import settings
 import dogesec_commons.objects.views as arango_views
-from dogesec_commons.stixifier.views import ProfileView, ExtractorsView
+from dogesec_commons.stixifier.views import ExtractorsView
+from obstracts.server.profiles import ProfileView
 from django.http import JsonResponse
 
 def handler404(*args, **kwargs):
@@ -89,4 +90,3 @@ urlpatterns = [
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-

--- a/tests/src/views/test_feed_view.py
+++ b/tests/src/views/test_feed_view.py
@@ -103,6 +103,20 @@ def test_create(
             assert feed_obj.admiralty_source_reliability == admiralty_source_reliability
 
 
+@pytest.mark.django_db
+def test_create_rejects_unsupported_media_type(client, api_schema):
+    resp = client.post(
+        "/api/v1/feeds/",
+        data=b"unsupported",
+        content_type="application/octet-stream",
+    )
+
+    assert resp.status_code == 415
+    api_schema["/api/v1/feeds/"]["POST"].validate_response(
+        Transport.get_st_response(resp)
+    )
+
+
 @pytest.mark.parametrize(
     "admiralty_source_reliability",
     [

--- a/tests/src/views/test_profile_view.py
+++ b/tests/src/views/test_profile_view.py
@@ -1,0 +1,17 @@
+import pytest
+
+from tests.utils import Transport
+
+
+@pytest.mark.django_db
+def test_create_rejects_unsupported_media_type(client, api_schema):
+    resp = client.post(
+        "/api/v1/profiles/",
+        data=b"unsupported",
+        content_type="application/octet-stream",
+    )
+
+    assert resp.status_code == 415
+    api_schema["/api/v1/profiles/"]["POST"].validate_response(
+        Transport.get_st_response(resp)
+    )


### PR DESCRIPTION
Aligns the core local-test image workflow with the integration branch.\n\n- publishes mutable :test and immutable test-sha-* from develop\n- stops publishing the local-test tag from main\n\nValidation: workflow trigger/tag audit and git diff --check passed.