### PR TITLE
Bump nltk to 3.10.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -347,7 +347,7 @@ nest-asyncio==1.6.0
     # via llama-index-core
 networkx==3.6.1
     # via llama-index-core
-nltk==3.10.0
+nltk==3.10.3
     # via llama-index-core
 numpy==2.4.2
     # via


### PR DESCRIPTION
Recreates the remaining safe dependency update from wrong-base Dependabot PR #568 on current `develop`. This preserves `history4feed==1.2.13` and the already-landed `sqlparse==0.6.0`.