### PR TITLE
Document unsupported media for write APIs

### DIFF
--- a/obstracts/server/objects.py
+++ b/obstracts/server/objects.py
@@ -1,0 +1,20 @@
+from dogesec_commons.objects.views import (
+    DELETE_OBJECTS_RESPONSE,
+    ObjectsWithReportsView as CommonsObjectsWithReportsView,
+)
+from drf_spectacular.utils import extend_schema, extend_schema_view
+
+from . import autoschema as api_schema
+
+
+@extend_schema_view(
+    delete_multi=extend_schema(
+        responses={
+            200: DELETE_OBJECTS_RESPONSE,
+            415: api_schema.DEFAULT_415_ERROR,
+        }
+    )
+)
+class ObjectsWithReportsView(CommonsObjectsWithReportsView):
+    """Project schema additions for the shared object endpoints."""
+

--- a/obstracts/server/views.py
+++ b/obstracts/server/views.py
@@ -151,9 +151,13 @@ class PlainMarkdownRenderer(renderers.BaseRenderer):
             """
         ),
     ),
-    create_skeleton=extend_schema(
+    skeleton=extend_schema(
         request=serializers.SkeletonFeedSerializer,
-        responses={201: FeedCreateSerializer, 400: api_schema.DEFAULT_400_ERROR},
+        responses={
+            201: FeedCreateSerializer,
+            400: api_schema.DEFAULT_400_ERROR,
+            415: api_schema.DEFAULT_415_ERROR,
+        },
         summary="Create a New Skeleton Feed",
         description=textwrap.dedent(
             """
@@ -194,6 +198,7 @@ class PlainMarkdownRenderer(renderers.BaseRenderer):
             201: serializers.FeedCreateSerializer,
             404: api_schema.DEFAULT_404_ERROR,
             400: api_schema.DEFAULT_400_ERROR,
+            415: api_schema.DEFAULT_415_ERROR,
         },
         summary="Update a Feeds Metadata",
         description=textwrap.dedent(
@@ -224,6 +229,7 @@ class PlainMarkdownRenderer(renderers.BaseRenderer):
             201: serializers.ObstractsJobSerializer,
             404: api_schema.DEFAULT_404_ERROR,
             400: api_schema.DEFAULT_400_ERROR,
+            415: api_schema.DEFAULT_415_ERROR,
         },
         summary="Fetch Updates for a Feed",
         description=textwrap.dedent(
@@ -253,6 +259,7 @@ class PlainMarkdownRenderer(renderers.BaseRenderer):
             201: ObstractsJobSerializer,
             404: api_schema.DEFAULT_404_ERROR,
             400: api_schema.DEFAULT_400_ERROR,
+            415: api_schema.DEFAULT_415_ERROR,
         },
         summary="Regenerate PDFs for all Posts in Feed",
         description=textwrap.dedent(
@@ -291,6 +298,7 @@ class PlainMarkdownRenderer(renderers.BaseRenderer):
             201: ObstractsJobSerializer,
             404: api_schema.DEFAULT_404_ERROR,
             400: api_schema.DEFAULT_400_ERROR,
+            415: api_schema.DEFAULT_415_ERROR,
         },
         request=serializers.ReprocessFeedPostsSerializer,
     ),
@@ -493,6 +501,7 @@ def get_retrieve_serializer_class(serializer_class):
             201: ObstractsJobSerializer,
             404: api_schema.DEFAULT_404_ERROR,
             400: api_schema.DEFAULT_400_ERROR,
+            415: api_schema.DEFAULT_415_ERROR,
         },
         summary="Update a Post in a Feed",
         description=textwrap.dedent(
@@ -537,6 +546,7 @@ def get_retrieve_serializer_class(serializer_class):
             201: serializers.PostWithFeedIDSerializer,
             404: api_schema.DEFAULT_404_ERROR,
             400: api_schema.DEFAULT_400_ERROR,
+            415: api_schema.DEFAULT_415_ERROR,
         },
         request=serializers.PatchPostSerializer,
     ),
@@ -592,6 +602,7 @@ def get_retrieve_serializer_class(serializer_class):
             201: ObstractsJobSerializer,
             404: api_schema.DEFAULT_404_ERROR,
             400: api_schema.DEFAULT_400_ERROR,
+            415: api_schema.DEFAULT_415_ERROR,
         },
         request=serializers.ReprocessSinglePostSerializer,
     ),
@@ -1039,6 +1050,7 @@ class PostOnlyView(h4f_views.PostOnlyView):
             201: ObstractsJobSerializer,
             404: api_schema.DEFAULT_404_ERROR,
             400: api_schema.DEFAULT_400_ERROR,
+            415: api_schema.DEFAULT_415_ERROR,
         },
         summary="Manually add a Post to A Feed",
         description=textwrap.dedent(
@@ -1088,6 +1100,7 @@ class PostOnlyView(h4f_views.PostOnlyView):
             201: ObstractsJobSerializer,
             404: api_schema.DEFAULT_404_ERROR,
             400: api_schema.DEFAULT_400_ERROR,
+            415: api_schema.DEFAULT_415_ERROR,
         },
         request=serializers.ReindexFeedSerializer,
     ),
@@ -1113,6 +1126,13 @@ class PostOnlyView(h4f_views.PostOnlyView):
             * if `skip_extraction=false` the data file will also be deleted before reprocessing. This request can also incur AI costs as will go back to AI for extractions, relationship, Attack Flow, etc generation.
             """
         ),
+        responses={
+            201: ObstractsJobSerializer,
+            404: api_schema.DEFAULT_404_ERROR,
+            400: api_schema.DEFAULT_400_ERROR,
+            415: api_schema.DEFAULT_415_ERROR,
+        },
+        request=serializers.ReprocessSinglePostSerializer,
     ),
 )
 class FeedPostView(h4f_views.feed_post_view, PostOnlyView):

--- a/obstracts/urls.py
+++ b/obstracts/urls.py
@@ -27,6 +27,7 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, Spec
 from django.conf import settings
 import dogesec_commons.objects.views as arango_views
 from dogesec_commons.stixifier.views import ExtractorsView
+from obstracts.server.objects import ObjectsWithReportsView
 from obstracts.server.profiles import ProfileView
 from django.http import JsonResponse
 
@@ -57,7 +58,7 @@ router.register('h4f_jobs', views.h4f_views.JobView, "h4f-job-view")
 ## objects
 regex_router = routers.SimpleRouter(use_regex_path=True)
 regex_router.register('identities', IdentityView, "identity-view")
-regex_router.register("objects", arango_views.ObjectsWithReportsView, "object-view-orig")
+regex_router.register("objects", ObjectsWithReportsView, "object-view-orig")
 regex_router.register('objects/smos', arango_views.SMOView, "object-view-smo")
 regex_router.register('objects/scos', arango_views.SCOView, "object-view-sco")
 regex_router.register('objects/sros', arango_views.SROView, "object-view-sro")

--- a/tests/src/views/test_unsupported_media.py
+++ b/tests/src/views/test_unsupported_media.py
@@ -1,0 +1,50 @@
+import pytest
+
+from tests.utils import Transport
+
+
+WRITE_OPERATIONS_WITH_BODIES = [
+    ("POST", "/api/v1/feeds/"),
+    ("PATCH", "/api/v1/feeds/{feed_id}/"),
+    ("PATCH", "/api/v1/feeds/{feed_id}/fetch/"),
+    ("POST", "/api/v1/feeds/{feed_id}/posts/"),
+    ("PATCH", "/api/v1/feeds/{feed_id}/posts/{post_id}/"),
+    ("PATCH", "/api/v1/feeds/{feed_id}/posts/{post_id}/reindex/"),
+    ("PATCH", "/api/v1/feeds/{feed_id}/posts/{post_id}/reprocess/"),
+    ("PATCH", "/api/v1/feeds/{feed_id}/posts/reindex/"),
+    ("PATCH", "/api/v1/feeds/{feed_id}/reindex-pdfs/"),
+    ("PATCH", "/api/v1/feeds/{feed_id}/reprocess-posts/"),
+    ("POST", "/api/v1/feeds/skeleton/"),
+    (
+        "POST",
+        "/api/v1/objects/reports/{report_id}/remove_objects/",
+    ),
+    ("PATCH", "/api/v1/posts/{post_id}/"),
+    ("PATCH", "/api/v1/posts/{post_id}/reindex/"),
+    ("PATCH", "/api/v1/posts/{post_id}/reprocess/"),
+    ("POST", "/api/v1/profiles/"),
+    ("PATCH", "/api/v1/topics/build_clusters/"),
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(("method", "schema_path"), WRITE_OPERATIONS_WITH_BODIES)
+def test_write_operations_document_unsupported_media_type(
+    client, api_schema, feed_with_posts, method, schema_path
+):
+    request_path = schema_path.format(
+        feed_id=feed_with_posts.pk,
+        post_id="561ed102-7584-4b7d-a302-43d4bca5605b",
+        report_id="report--00000000-0000-4000-8000-000000000001",
+    )
+    response = client.generic(
+        method,
+        request_path,
+        data=b"unsupported",
+        content_type="application/octet-stream",
+    )
+
+    assert response.status_code == 415
+    api_schema[schema_path][method].validate_response(
+        Transport.get_st_response(response)
+    )


### PR DESCRIPTION
Completes the 415 response schema across every POST/PATCH operation with a request body, including inherited feed and object endpoints. Verification: parameterized regression 17 passed; machine audit found zero request-body write operations missing 415; full local Schemathesis suite 72 passed.