### PR TITLE
Resolve staging promotion workflow conflict

### DIFF
--- a/.github/workflows/rebuild-staging-image.yml
+++ b/.github/workflows/rebuild-staging-image.yml
@@ -1,8 +1,7 @@
-name: Create and publish the Docker image for Obstracts Web Staging
+name: Rebuild and publish the Docker image for Obstracts Web Staging
 
 on:
-  push:
-    branches: ['staging']
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -16,8 +15,13 @@ jobs:
       contents: read
       packages: write
       attestations: write
-      id-token: write 
+      id-token: write
     steps:
+      - name: Verify staging ref
+        if: github.ref != 'refs/heads/staging'
+        run: |
+          echo "Staging images may only be rebuilt from the staging branch." >&2
+          exit 1
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Log in to the Container registry


### PR DESCRIPTION
Separates the guarded manual staging-image rebuild into its own workflow and restores the automatic staging workflow to the main-compatible version. This resolves the history-independent workflow conflict in #569 without rewriting protected branches or promoting to production.\n\nThe manual workflow is intentionally dispatch-only and rejects any ref other than staging before checkout, registry login, or build. Its publishing steps remain identical to the automatic staging workflow. It becomes available in the Actions UI once this release state eventually reaches the default branch.