### PR TITLE
Reconcile staging promotion workflow

### DIFF
--- a/.github/workflows/rebuild-staging-image.yml
+++ b/.github/workflows/rebuild-staging-image.yml
@@ -1,8 +1,7 @@
-name: Create and publish the Docker image for Obstracts Web Staging
+name: Rebuild and publish the Docker image for Obstracts Web Staging
 
 on:
-  push:
-    branches: ['staging']
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -16,8 +15,13 @@ jobs:
       contents: read
       packages: write
       attestations: write
-      id-token: write 
+      id-token: write
     steps:
+      - name: Verify staging ref
+        if: github.ref != 'refs/heads/staging'
+        run: |
+          echo "Staging images may only be rebuilt from the staging branch." >&2
+          exit 1
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Log in to the Container registry


### PR DESCRIPTION
Applies the exact reviewed and develop-tested workflow reconciliation to staging through the allowed hotfix path.\n\nThis preserves automatic staging image publication, keeps manual rebuilding in a staging-only guarded workflow, and removes the workflow conflict blocking #569. It does not promote or modify main.