### PR TITLE
Guard GHCR cleanup by active image channel

### DIFF
--- a/.github/scripts/cleanup-ghcr-versions.mjs
+++ b/.github/scripts/cleanup-ghcr-versions.mjs
@@ -160,9 +160,25 @@ function inspectManifest(document, digest) {
 
 export async function planRetention(
   versions,
-  { manifestForDigest },
+  { manifestForDigest, expectedChannel },
 ) {
   const normalized = normalizeVersions(versions);
+  if (!CHANNELS.includes(expectedChannel)) {
+    throw new Error(
+      `EXPECTED_CHANNEL must be one of ${CHANNELS.join(", ")}`,
+    );
+  }
+  // A package can legitimately predate one or more release channels, but the
+  // workflow that just published must be able to observe exactly one moving
+  // tag for its own channel before this process is allowed to plan deletions.
+  const activeRoots = normalized.filter((version) =>
+    version.tags.includes(expectedChannel),
+  );
+  if (activeRoots.length !== 1) {
+    throw new Error(
+      `expected exactly one package version carrying the active ${expectedChannel} tag; found ${activeRoots.length}`,
+    );
+  }
   const roots = selectReleaseRoots(normalized);
   const byDigest = new Map();
   const fallbackBySubject = new Map();
@@ -347,13 +363,15 @@ export async function deleteVersions(owner, packageName, versions, request = git
 async function main() {
   const owner = process.env.GITHUB_REPOSITORY_OWNER;
   const packageName = process.env.PACKAGE_NAME;
-  if (!owner || !packageName || !process.env.GITHUB_TOKEN || !process.env.GITHUB_ACTOR) {
-    throw new Error("GITHUB_REPOSITORY_OWNER, PACKAGE_NAME, GITHUB_ACTOR, and GITHUB_TOKEN are required");
+  const expectedChannel = process.env.EXPECTED_CHANNEL;
+  if (!owner || !packageName || !process.env.GITHUB_TOKEN || !process.env.GITHUB_ACTOR || !expectedChannel) {
+    throw new Error("GITHUB_REPOSITORY_OWNER, PACKAGE_NAME, GITHUB_ACTOR, GITHUB_TOKEN, and EXPECTED_CHANNEL are required");
   }
 
   const versions = await listVersions(owner, packageName);
   const plan = await planRetention(versions, {
     manifestForDigest: (digest) => registryManifest(owner, packageName, digest),
+    expectedChannel,
   });
   console.log(`Keeping ${plan.keep.length} package versions.`);
   await deleteVersions(owner, packageName, plan.remove);

--- a/.github/scripts/cleanup-ghcr-versions.test.mjs
+++ b/.github/scripts/cleanup-ghcr-versions.test.mjs
@@ -26,8 +26,9 @@ function immutable(channel, character) {
   return `sha-${channel}-${character.repeat(40)}`;
 }
 
-function emptyRegistry(overrides = {}) {
+function emptyRegistry(overrides = {}, expectedChannel = "prod") {
   return {
+    expectedChannel,
     manifestForDigest: async (digest) => overrides.manifests?.[digest] ?? {
       schemaVersion: 2,
       mediaType: "application/vnd.oci.image.manifest.v1+json",
@@ -106,7 +107,7 @@ test("retains a fallback referrer index and its children", async () => {
     manifests: {
       [fallback]: index([{ digest: attestation }]),
     },
-  }));
+  }, "staging"));
   assert.deepEqual(plan.keep.map(({ id }) => id), [10, 11, 12]);
   assert.deepEqual(plan.remove.map(({ id }) => id), [13]);
 });
@@ -125,7 +126,7 @@ test("does not retain an obsolete parent merely because it shares a child", asyn
       [kept]: index([{ digest: shared }]),
       [obsolete]: index([{ digest: shared }]),
     },
-  }));
+  }, "test"));
   assert.deepEqual(plan.keep.map(({ id }) => id), [20, 21]);
   assert.deepEqual(plan.remove.map(({ id }) => id), [22]);
 });
@@ -138,7 +139,7 @@ test("deletes exact old tagged and untagged candidates", async () => {
     version(4, "2026-01-04T00:00:00Z", ["test", immutable("test", "d")]),
     version(5, "2026-01-05T00:00:00Z"),
   ];
-  const plan = await planRetention(versions, emptyRegistry());
+  const plan = await planRetention(versions, emptyRegistry({}, "test"));
 
   assert.deepEqual(plan.keep.map(({ id }) => id), [2, 3, 4]);
   assert.deepEqual(plan.remove.map(({ id }) => id), [1, 5]);
@@ -162,6 +163,55 @@ test("supports legacy current tags during migration", () => {
     version(4, "2025-12-01T00:00:00Z", ["sha-d4"]),
   ]);
   assert.deepEqual(roots.map(({ id }) => id), [1, 2, 3]);
+});
+
+test("rejects a missing active publishing channel before registry inspection or deletion planning", async () => {
+  let manifestReads = 0;
+  await assert.rejects(
+    planRetention([
+      version(1, "2026-01-01T00:00:00Z", ["staging", "sha-a1"]),
+    ], {
+      expectedChannel: "test",
+      manifestForDigest: async () => {
+        manifestReads += 1;
+        return {
+          schemaVersion: 2,
+          mediaType: "application/vnd.oci.image.manifest.v1+json",
+        };
+      },
+    }),
+    /exactly one package version carrying the active test tag; found 0/,
+  );
+  assert.equal(manifestReads, 0);
+});
+
+test("preserves a live legacy staging closure while publishing test", async () => {
+  const staging = digest(50);
+  const stagingPlatform = digest(51);
+  const currentTest = digest(52);
+  const obsolete = digest(53);
+  const plan = await planRetention([
+    version(50, "2026-01-01T00:00:00Z", ["staging", "sha-e1071ae"], staging),
+    version(51, "2026-01-01T00:00:00Z", [], stagingPlatform),
+    version(52, "2026-01-02T00:00:00Z", ["test", immutable("test", "a")], currentTest),
+    version(53, "2025-01-01T00:00:00Z", [], obsolete),
+  ], emptyRegistry({
+    manifests: {
+      [staging]: index([{ digest: stagingPlatform }]),
+    },
+  }, "test"));
+
+  assert.deepEqual(plan.keep.map(({ id }) => id), [50, 51, 52]);
+  assert.deepEqual(plan.remove.map(({ id }) => id), [53]);
+});
+
+test("allows an unrelated production channel to be absent", async () => {
+  const plan = await planRetention([
+    version(60, "2026-01-01T00:00:00Z", ["test", immutable("test", "b")]),
+  ], emptyRegistry({}, "test"));
+
+  assert.deepEqual(plan.keep.map(({ id }) => id), [60]);
+  assert.deepEqual(plan.remove, []);
 });
 
 test("paginates through more than 100 package versions", async () => {
@@ -231,12 +281,14 @@ test("fails closed on registry errors and malformed manifests", async () => {
   const root = version(1, "2026-01-01T00:00:00Z", ["prod", immutable("prod", "a")]);
   await assert.rejects(
     planRetention([root], {
+      expectedChannel: "prod",
       manifestForDigest: async () => { throw new Error("registry unavailable"); },
     }),
     /registry unavailable/,
   );
   await assert.rejects(
     planRetention([root], {
+      expectedChannel: "prod",
       manifestForDigest: async () => null,
     }),
     /not a valid schema-version 2 manifest/,

--- a/.github/workflows/deploy-production-image.yml
+++ b/.github/workflows/deploy-production-image.yml
@@ -61,5 +61,6 @@ jobs:
           push-to-registry: true
       - name: Apply channel-aware GHCR retention
         env:
+          EXPECTED_CHANNEL: prod
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/cleanup-ghcr-versions.mjs

--- a/.github/workflows/deploy-staging-image.yml
+++ b/.github/workflows/deploy-staging-image.yml
@@ -62,5 +62,6 @@ jobs:
           push-to-registry: true
       - name: Apply channel-aware GHCR retention
         env:
+          EXPECTED_CHANNEL: staging
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/cleanup-ghcr-versions.mjs

--- a/.github/workflows/deploy-test-image.yml
+++ b/.github/workflows/deploy-test-image.yml
@@ -60,5 +60,6 @@ jobs:
           push-to-registry: true
       - name: Apply channel-aware GHCR retention
         env:
+          EXPECTED_CHANNEL: test
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/cleanup-ghcr-versions.mjs

--- a/.github/workflows/rebuild-staging-image.yml
+++ b/.github/workflows/rebuild-staging-image.yml
@@ -66,5 +66,6 @@ jobs:
           push-to-registry: true
       - name: Apply channel-aware GHCR retention
         env:
+          EXPECTED_CHANNEL: staging
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/cleanup-ghcr-versions.mjs


### PR DESCRIPTION
Links to muchdogesec/obstracts_web_deploy#76.

Incident evidence:
- Legacy run 34443461858 used the global keep-five action and deleted the staging root.
- Tag-aware run 34444887000 did not delete the staging root; it was already absent.

Hardening:
- Require EXPECTED_CHANNEL to resolve to exactly one moving channel tag before any deletion.
- Allow unrelated channels that have not yet been initialized.
- Preserve every moving channel root that is present and its required OCI closure.
- Fail closed before deletion on invalid active-channel state.

Verification:
- Local tests: 18/18 passed.
- JavaScript syntax, workflow YAML, and diff checks passed.
- Independent review: APPROVE at 24a66f8b5b5b979f39d0b7261b26f61f502eac78.

No image publication or deployment is included.