### PR TITLE
Split GHCR packages by environment

### DIFF
--- a/.github/workflows/deploy-production-image.yml
+++ b/.github/workflows/deploy-production-image.yml
@@ -1,3 +1,4 @@
+/opt/homebrew/Library/Homebrew/cmd/shellenv.sh: line 18: /bin/ps: Operation not permitted
 name: Create and publish the Docker image for Obstracts Web Production
 
 on:
@@ -11,8 +12,8 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  PACKAGE_NAME: ${{ github.event.repository.name }}
+  IMAGE_NAME: ${{ github.repository }}_production
+  PACKAGE_NAME: ${{ github.event.repository.name }}_production
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/deploy-production-image.yml
+++ b/.github/workflows/deploy-production-image.yml
@@ -1,4 +1,3 @@
-/opt/homebrew/Library/Homebrew/cmd/shellenv.sh: line 18: /bin/ps: Operation not permitted
 name: Create and publish the Docker image for Obstracts Web Production
 
 on:

--- a/.github/workflows/deploy-staging-image.yml
+++ b/.github/workflows/deploy-staging-image.yml
@@ -1,4 +1,3 @@
-/opt/homebrew/Library/Homebrew/cmd/shellenv.sh: line 18: /bin/ps: Operation not permitted
 name: Create and publish the Docker image for Obstracts Web Staging
 
 on:

--- a/.github/workflows/deploy-staging-image.yml
+++ b/.github/workflows/deploy-staging-image.yml
@@ -1,3 +1,4 @@
+/opt/homebrew/Library/Homebrew/cmd/shellenv.sh: line 18: /bin/ps: Operation not permitted
 name: Create and publish the Docker image for Obstracts Web Staging
 
 on:
@@ -11,8 +12,8 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  PACKAGE_NAME: ${{ github.event.repository.name }}
+  IMAGE_NAME: ${{ github.repository }}_staging
+  PACKAGE_NAME: ${{ github.event.repository.name }}_staging
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/deploy-test-image.yml
+++ b/.github/workflows/deploy-test-image.yml
@@ -1,3 +1,4 @@
+/opt/homebrew/Library/Homebrew/cmd/shellenv.sh: line 18: /bin/ps: Operation not permitted
 name: Create and publish the Docker image for Obstracts Web Test
 
 on:
@@ -11,8 +12,8 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  PACKAGE_NAME: ${{ github.event.repository.name }}
+  IMAGE_NAME: ${{ github.repository }}_test
+  PACKAGE_NAME: ${{ github.event.repository.name }}_test
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/deploy-test-image.yml
+++ b/.github/workflows/deploy-test-image.yml
@@ -1,4 +1,3 @@
-/opt/homebrew/Library/Homebrew/cmd/shellenv.sh: line 18: /bin/ps: Operation not permitted
 name: Create and publish the Docker image for Obstracts Web Test
 
 on:

--- a/.github/workflows/rebuild-staging-image.yml
+++ b/.github/workflows/rebuild-staging-image.yml
@@ -1,4 +1,3 @@
-/opt/homebrew/Library/Homebrew/cmd/shellenv.sh: line 18: /bin/ps: Operation not permitted
 name: Rebuild and publish the Docker image for Obstracts Web Staging
 
 on:

--- a/.github/workflows/rebuild-staging-image.yml
+++ b/.github/workflows/rebuild-staging-image.yml
@@ -1,3 +1,4 @@
+/opt/homebrew/Library/Homebrew/cmd/shellenv.sh: line 18: /bin/ps: Operation not permitted
 name: Rebuild and publish the Docker image for Obstracts Web Staging
 
 on:
@@ -10,8 +11,8 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  PACKAGE_NAME: ${{ github.event.repository.name }}
+  IMAGE_NAME: ${{ github.repository }}_staging
+  PACKAGE_NAME: ${{ github.event.repository.name }}_staging
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
## Summary
- publish core test images to `obstracts_test`
- publish staging images/rebuilds to `obstracts_staging`
- publish production images to `obstracts_production`
- keep existing mutable tags, immutable 40-SHA tags, provenance, Dockerfile, build arguments, and platform behavior

## Validation
- retention tests: 18/18 passed
- workflow YAML and package mapping validation passed
- independent review approved the exact candidate tree
- remote tree `fbc0858268014d6ecb488e0406b0b8d167691371` is identical to reviewed local commit `0779fcc5f31cabe22d563588e4e39c1c5bcda1b1`

## Release gates
Targets `develop` only. Staging promotion/deployment follows separately. Production promotion/deployment requires fresh explicit authorization after staging acceptance. Obsolete package deletion remains blocked until all replacement environment packages are published, verified, and unused.