### PR TITLE
Correct core GHCR package names

### DIFF
--- a/.github/workflows/deploy-production-image.yml
+++ b/.github/workflows/deploy-production-image.yml
@@ -11,8 +11,8 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}_production
-  PACKAGE_NAME: ${{ github.event.repository.name }}_production
+  IMAGE_NAME: ${{ github.repository_owner }}/obstracts_web_production
+  PACKAGE_NAME: obstracts_web_production
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/deploy-staging-image.yml
+++ b/.github/workflows/deploy-staging-image.yml
@@ -11,8 +11,8 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}_staging
-  PACKAGE_NAME: ${{ github.event.repository.name }}_staging
+  IMAGE_NAME: ${{ github.repository_owner }}/obstracts_web_staging
+  PACKAGE_NAME: obstracts_web_staging
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/deploy-test-image.yml
+++ b/.github/workflows/deploy-test-image.yml
@@ -11,8 +11,8 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}_test
-  PACKAGE_NAME: ${{ github.event.repository.name }}_test
+  IMAGE_NAME: ${{ github.repository_owner }}/obstracts_web_test
+  PACKAGE_NAME: obstracts_web_test
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/rebuild-staging-image.yml
+++ b/.github/workflows/rebuild-staging-image.yml
@@ -10,8 +10,8 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}_staging
-  PACKAGE_NAME: ${{ github.event.repository.name }}_staging
+  IMAGE_NAME: ${{ github.repository_owner }}/obstracts_web_staging
+  PACKAGE_NAME: obstracts_web_staging
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
## Summary
- correct core test image package to `obstracts_web_test`
- correct core staging image and rebuild package to `obstracts_web_staging`
- correct core production image package to `obstracts_web_production`
- preserve mutable channel tags, immutable 40-SHA tags, provenance, retention, Dockerfile, build arguments, and platform behavior

## Validation
- retention tests: 18/18 passed
- workflow YAML parse and exact-name scans passed
- independent review approved the exact candidate tree
- remote tree `16946907d4ea0d727d9705bd46283faf6faf11c0` matches local reviewed commit `c2b26fd9992fe693bc9e1912ca497a8441a856e9`

## Scope
Publisher GitHub Actions only. No GHCR package deletion.